### PR TITLE
Token Balances

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -11,7 +11,7 @@ import {
 } from "viem/chains";
 
 // All supported networks
-const SUPPORTED_NETWORKS = createNetworkMap([
+export const SUPPORTED_NETWORKS = createNetworkMap([
   mainnet,
   gnosis,
   sepolia,
@@ -58,7 +58,7 @@ export class Network implements NetworkFields {
   }
 }
 
-type NetworkMap = { [key: number]: NetworkFields };
+export type NetworkMap = { [key: number]: NetworkFields };
 
 /// Dynamically generate network map accessible by chainId.
 function createNetworkMap(supportedNetworks: Chain[]): NetworkMap {

--- a/src/token/balance.ts
+++ b/src/token/balance.ts
@@ -1,0 +1,45 @@
+import { JsonRpcProvider, ethers } from "ethers";
+import { NetworkMap } from "../network";
+import { TOKEN_LIST } from "./list";
+
+// This function fetches the balance of a specific ERC-20 token for a given address.
+export async function getSingleTokenBalance(
+  tokenAddress: string,
+  walletAddress: string,
+  provider: JsonRpcProvider
+): Promise<bigint> {
+  // Define the ERC-20 token ABI (only the `balanceOf` function is necessary for this task)
+  const tokenAbi = ["function balanceOf(address owner) view returns (uint256)"];
+
+  // Create a new ethers Contract instance to interact with the token
+  const tokenContract = new ethers.Contract(tokenAddress, tokenAbi, provider);
+
+  // Fetch the token balance
+  const balanceWei: bigint = await tokenContract.balanceOf(walletAddress);
+
+  // Convert the balance from wei to a more readable format (assuming it's a standard ERC-20 with 18 decimals)
+  return balanceWei;
+}
+
+export async function getBalancesForAccount(
+  walletAddress: string,
+  networks: NetworkMap
+): Promise<void> {
+  for (const [key, network] of Object.entries(networks)) {
+    const provider = new ethers.JsonRpcProvider(network.rpcUrl);
+    const tokens = TOKEN_LIST[network.chainId];
+    console.log(key, network, tokens);
+    if (tokens !== undefined) {
+      const balances = await Promise.all(
+        tokens.map((x) =>
+          getSingleTokenBalance(x.address, walletAddress, provider)
+        )
+      );
+      console.log(
+        `Processed Balances for Chain ID: ${key}, got balances ${balances}`
+      );
+    } else {
+      console.log(`no tokens for ${network.name}`);
+    }
+  }
+}

--- a/src/token/list.ts
+++ b/src/token/list.ts
@@ -1,0 +1,102 @@
+type Token = {
+  symbol: string;
+  name: string;
+  address: string;
+  decimals: number;
+  chainId: number;
+  logoURI: string;
+};
+
+type TokenList = {
+  [key: number]: Token[];
+};
+
+export const TOKEN_LIST: TokenList = {
+  100: [
+    {
+      symbol: "COW",
+      name: "CoW Protocol Token",
+      address: "0x177127622c4A00F3d409B75571e12cB3c8973d3c",
+      decimals: 18,
+      chainId: 100,
+      logoURI:
+        "https://gateway.pinata.cloud/ipfs/QmQxFkVZzXFyWf73rcFwNPaEqG5hBwYXrwrBEX3aWJrn2r/cowprotocol.png",
+    },
+  ],
+  1: [
+    {
+      symbol: "USDC",
+      name: "USD Coin",
+      address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      decimals: 6,
+      chainId: 1,
+      logoURI:
+        "https://tokens.1inch.io/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png",
+    },
+    {
+      symbol: "WETH",
+      name: "Wrapped Ether",
+      address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      decimals: 18,
+      chainId: 1,
+      logoURI:
+        "https://tokens.1inch.io/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+    },
+    {
+      symbol: "USDT",
+      name: "Tether USD",
+      address: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+      decimals: 6,
+      chainId: 1,
+      logoURI:
+        "https://tokens.1inch.io/0xdac17f958d2ee523a2206206994597c13d831ec7.png",
+    },
+    {
+      symbol: "DAI",
+      name: "Dai Stablecoin",
+      address: "0x6b175474e89094c44da98b954eedeac495271d0f",
+      decimals: 18,
+      chainId: 1,
+      logoURI:
+        "https://tokens.1inch.io/0x6b175474e89094c44da98b954eedeac495271d0f.png",
+    },
+    {
+      symbol: "GNO",
+      name: "Gnosis",
+      address: "0x6810e776880c02933d47db1b9fc05908e5386b96",
+      decimals: 18,
+      chainId: 1,
+      logoURI:
+        "https://tokens.1inch.io/0x6810e776880c02933d47db1b9fc05908e5386b96.png",
+    },
+    {
+      symbol: "COW",
+      name: "CoW Protocol Token",
+      address: "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+      decimals: 18,
+      chainId: 1,
+      logoURI:
+        "https://gateway.pinata.cloud/ipfs/QmQxFkVZzXFyWf73rcFwNPaEqG5hBwYXrwrBEX3aWJrn2r/cowprotocol.png",
+    },
+  ],
+  11155111: [
+    {
+      symbol: "COW",
+      name: "CoW Protocol Token",
+      address: "0x0625afb445c3b6b7b929342a04a22599fd5dbb59",
+      decimals: 18,
+      chainId: 11155111,
+      logoURI:
+        "https://gateway.pinata.cloud/ipfs/QmQxFkVZzXFyWf73rcFwNPaEqG5hBwYXrwrBEX3aWJrn2r/cowprotocol.png",
+    },
+    {
+      symbol: "USDC",
+      name: "USDC (Sepolia)",
+      address: "0xbe72e441bf55620febc26715db68d3494213d8cb",
+      decimals: 6,
+      chainId: 11155111,
+      logoURI:
+        "https://tokens.1inch.io/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png",
+    },
+  ],
+};

--- a/tests/token.balance.test.ts
+++ b/tests/token.balance.test.ts
@@ -1,0 +1,29 @@
+import { sepolia } from "viem/chains";
+import {
+  getSingleTokenBalance,
+  getBalancesForAccount,
+} from "../src/token/balance";
+import { ethers } from "ethers";
+import { SUPPORTED_NETWORKS } from "../src/network";
+
+describe("Transaction Builder Functions", () => {
+  it("getBalance", async () => {
+    const provider = new ethers.JsonRpcProvider(
+      sepolia.rpcUrls.default.http[0]
+    );
+    const balance = await getSingleTokenBalance(
+      "0x0625afb445c3b6b7b929342a04a22599fd5dbb59",
+      "0x8d99F8b2710e6A3B94d9bf465A98E5273069aCBd",
+      provider
+    );
+    console.log(balance);
+  });
+
+  it.only("getBalance", async () => {
+    const balance = await getBalancesForAccount(
+      "0x8d99F8b2710e6A3B94d9bf465A98E5273069aCBd",
+      SUPPORTED_NETWORKS
+    );
+    console.log(balance);
+  });
+});


### PR DESCRIPTION
This is a self-hosted approach to fetching token balances for a given account address across many chains. 

It retrieves balances by making (simultaneous) direct rpc calls to `token.balanceOf(account)` for a fixed tokenList.

Some drawbacks here are 

- [maintenance] having a fixed token list. However, there are several publicly available token lists here: https://tokenlists.org/ so we don't need to maintain our own fixed list.
- [scalability] if the token list is too large, we will be limited by the node provider to too many simultaneous requests.

Alternative options:

There are services that offer token balances. For example
- Covalent: https://www.npmjs.com/package/@covalenthq/client-sdk
- TokenBalance (seems SUPER old -- only mainnet): [website](https://tokenbalance.com/) & ([github](https://github.com/hunterlong/tokenbalance))
- [Alchemy API](https://docs.alchemy.com/reference/alchemy-gettokenbalances): Tried it for one account on mainnet like so:

```sh
curl --request POST \
     --url https://eth-mainnet.g.alchemy.com/v2/$ALCHEMY_KEY \
     --header 'accept: application/json' \
     --header 'content-type: application/json' \
     --data '{"id": 1,"jsonrpc": "2.0","method": "alchemy_getTokenBalances","params": ["0x7f01D9b227593E033bf8d6FC86e634d27aa85568"]}'
```
it returned a page key and the docs are unclear on how to get the next page.
- [QuickNode](https://guides.quicknode.com/docs/ethereum/qn_getWalletTokenBalance_v2)
```sh
curl https://docs-demo.quiknode.pro/ \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{
    "id":67,
    "jsonrpc":"2.0",
    "method":"qn_getWalletTokenBalance",
    "params": [{
      "wallet": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
      "page": 2
    }]
  }'
```


cc @SurgeCode
