### PR TITLE
Lint: Align Lint & Format Commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "build": "rm -fr dist/* && yarn build:esm && yarn build:cjs",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
-    "lint": "eslint . --ignore-pattern dist/",
+    "lint": "eslint . --ignore-pattern dist/ && prettier --check **/*.ts",
     "test": "jest --testTimeout 30000",
     "coverage": "yarn test --coverage",
     "verify": "yarn lint && yarn coverage unit",
-    "fmt": "prettier --write '{src,examples,tests}/**/*.{js,jsx,ts,tsx}'"
+    "fmt": "prettier --write '{src,examples,tests}/**/*.{js,jsx,ts,tsx}' && eslint src/ --fix"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
#133 was passing lint while having invalid format. This is because lint was only checking eslint, but not prettier.

This PR ensures that both eslint and prettier (--check) are run in CI and additionally adds `eslint --fix` to the `yarn fmt`.