### PR TITLE
Attempt MultiSign

### DIFF
--- a/examples/send-eth.ts
+++ b/examples/send-eth.ts
@@ -1,16 +1,16 @@
 import dotenv from "dotenv";
-import { SEPOLIA_CHAIN_ID, setupNearEthAdapter } from "./setup";
+import { setupNearEthAdapter } from "./setup";
 dotenv.config();
 
 const run = async (): Promise<void> => {
   const evm = await setupNearEthAdapter();
-  await evm.signAndSendTransaction({
-    // Sending to self.
-    to: evm.address,
-    // THIS IS ONE WEI!
-    value: 1n,
-    chainId: SEPOLIA_CHAIN_ID,
-  });
+  console.log(evm.address);
+  // throw new Error("You foked up");
+  const transactions = [
+    { to: evm.address, value: 1n, chainId: 97 },
+    { to: evm.address, value: 1n, chainId: 1301 },
+  ];
+  await evm.signAndSendTransaction(transactions);
 };
 
 run();

--- a/src/utils/mock-sign.ts
+++ b/src/utils/mock-sign.ts
@@ -48,6 +48,15 @@ export class MockMpcContract implements IMpcContract {
         "0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d"
     );
   }
+  requestMulti(_signArgs: SignArgs[], _gas?: bigint): Promise<Signature[]> {
+    throw new Error("Method not implemented.");
+  }
+  encodeMulti(
+    _signArgs: SignArgs[],
+    _gas?: bigint
+  ): Promise<FunctionCallTransaction<{ request: SignArgs }>> {
+    throw new Error("Method not implemented.");
+  }
 
   accountId(): string {
     return "mock-mpc.offline";


### PR DESCRIPTION
This thing is complaining about `requestMulti`. I have tried everything it suggests, but it won't accept.

Seems like disagreement with near-api-js and near wallet selector... not sure. The types have certainly changed since I last looked. 


To try:

```sh
npx tsx examples/send-eth.ts
```

<details> <Summary> Error with Borsch </summary>

```
/Users/bh2smith/Projects/mintbase/evm/near-ca/node_modules/borsh/lib/cjs/serialize.js:117
        throw new Error("Enum key (".concat(valueKey, ") not found in enum schema: ").concat(JSON.stringify(schema), " at ").concat(this.fieldPath.join('.')));
              ^

Error: Enum key (enum) not found in enum schema: {"enum":[{"struct":{"createAccount":{"struct":{}}}},{"struct":{"deployContract":{"struct":{"code":{"array":{"type":"u8"}}}}}},{"struct":{"functionCall":{"struct":{"methodName":"string","args":{"array":{"type":"u8"}},"gas":"u64","deposit":"u128"}}}},{"struct":{"transfer":{"struct":{"deposit":"u128"}}}},{"struct":{"stake":{"struct":{"stake":"u128","publicKey":{"enum":[{"struct":{"ed25519Key":{"struct":{"data":{"array":{"type":"u8","len":32}}}}}},{"struct":{"secp256k1Key":{"struct":{"data":{"array":{"type":"u8","len":64}}}}}}]}}}}},{"struct":{"addKey":{"struct":{"publicKey":{"enum":[{"struct":{"ed25519Key":{"struct":{"data":{"array":{"type":"u8","len":32}}}}}},{"struct":{"secp256k1Key":{"struct":{"data":{"array":{"type":"u8","len":64}}}}}}]},"accessKey":{"struct":{"nonce":"u64","permission":{"enum":[{"struct":{"functionCall":{"struct":{"allowance":{"option":"u128"},"receiverId":"string","methodNames":{"array":{"type":"string"}}}}}},{"struct":{"fullAccess":{"struct":{}}}}]}}}}}}},{"struct":{"deleteKey":{"struct":{"publicKey":{"enum":[{"struct":{"ed25519Key":{"struct":{"data":{"array":{"type":"u8","len":32}}}}}},{"struct":{"secp256k1Key":{"struct":{"data":{"array":{"type":"u8","len":64}}}}}}]}}}}},{"struct":{"deleteAccount":{"struct":{"beneficiaryId":"string"}}}},{"struct":{"signedDelegate":{"struct":{"delegateAction":{"struct":{"senderId":"string","receiverId":"string","actions":{"array":{"type":{"enum":[{"struct":{"createAccount":{"struct":{}}}},{"struct":{"deployContract":{"struct":{"code":{"array":{"type":"u8"}}}}}},{"struct":{"functionCall":{"struct":{"methodName":"string","args":{"array":{"type":"u8"}},"gas":"u64","deposit":"u128"}}}},{"struct":{"transfer":{"struct":{"deposit":"u128"}}}},{"struct":{"stake":{"struct":{"stake":"u128","publicKey":{"enum":[{"struct":{"ed25519Key":{"struct":{"data":{"array":{"type":"u8","len":32}}}}}},{"struct":{"secp256k1Key":{"struct":{"data":{"array":{"type":"u8","len":64}}}}}}]}}}}},{"struct":{"addKey":{"struct":{"publicKey":{"enum":[{"struct":{"ed25519Key":{"struct":{"data":{"array":{"type":"u8","len":32}}}}}},{"struct":{"secp256k1Key":{"struct":{"data":{"array":{"type":"u8","len":64}}}}}}]},"accessKey":{"struct":{"nonce":"u64","permission":{"enum":[{"struct":{"functionCall":{"struct":{"allowance":{"option":"u128"},"receiverId":"string","methodNames":{"array":{"type":"string"}}}}}},{"struct":{"fullAccess":{"struct":{}}}}]}}}}}}},{"struct":{"deleteKey":{"struct":{"publicKey":{"enum":[{"struct":{"ed25519Key":{"struct":{"data":{"array":{"type":"u8","len":32}}}}}},{"struct":{"secp256k1Key":{"struct":{"data":{"array":{"type":"u8","len":64}}}}}}]}}}}},{"struct":{"deleteAccount":{"struct":{"beneficiaryId":"string"}}}}]}}},"nonce":"u64","maxBlockHeight":"u64","publicKey":{"enum":[{"struct":{"ed25519Key":{"struct":{"data":{"array":{"type":"u8","len":32}}}}}},{"struct":{"secp256k1Key":{"struct":{"data":{"array":{"type":"u8","len":64}}}}}}]}}},"signature":{"enum":[{"struct":{"ed25519Signature":{"struct":{"data":{"array":{"type":"u8","len":64}}}}}},{"struct":{"secp256k1Signature":{"struct":{"data":{"array":{"type":"u8","len":65}}}}}}]}}}}}]} at value.actions
    at BorshSerializer.encode_enum (/Users/bh2smith/Projects/mintbase/evm/near-ca/node_modules/borsh/lib/cjs/serialize.js:117:15)
    at BorshSerializer.encode_value (/Users/bh2smith/Projects/mintbase/evm/near-ca/node_modules/borsh/lib/cjs/serialize.js:53:29)
    at BorshSerializer.encode_arraylike (/Users/bh2smith/Projects/mintbase/evm/near-ca/node_modules/borsh/lib/cjs/serialize.js:136:18)
    at BorshSerializer.encode_array (/Users/bh2smith/Projects/mintbase/evm/near-ca/node_modules/borsh/lib/cjs/serialize.js:121:25)
    at BorshSerializer.encode_value (/Users/bh2smith/Projects/mintbase/evm/near-ca/node_modules/borsh/lib/cjs/serialize.js:55:29)
    at BorshSerializer.encode_struct (/Users/bh2smith/Projects/mintbase/evm/near-ca/node_modules/borsh/lib/cjs/serialize.js:180:18)
    at BorshSerializer.encode_value (/Users/bh2smith/Projects/mintbase/evm/near-ca/node_modules/borsh/lib/cjs/serialize.js:61:29)
    at BorshSerializer.encode (/Users/bh2smith/Projects/mintbase/evm/near-ca/node_modules/borsh/lib/cjs/serialize.js:37:14)
    at serialize (/Users/bh2smith/Projects/mintbase/evm/near-ca/node_modules/borsh/lib/cjs/index.js:35:23)
    at encodeTransaction (/Users/bh2smith/Projects/mintbase/evm/near-ca/node_modules/@near-js/transactions/lib/commonjs/schema.cjs:34:34)
```
</details>
