### PR TITLE
Manually Sign, Broadcast and Poll Signature Requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@walletconnect/web3wallet": "^1.13.0",
     "elliptic": "^6.5.6",
-    "near-api-js": "^5.0.0",
+    "near-api-js": "^5.0.1",
     "viem": "^2.21.37"
   }
 }

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -60,7 +60,7 @@ describe("End To End", () => {
         chainId,
       })
     ).rejects.toThrow();
-  });
+  }, 15000);
 
   it("signMessage", async () => {
     const message = "NearEth";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3794,7 +3794,7 @@ near-abi@0.1.1:
   dependencies:
     "@types/json-schema" "^7.0.11"
 
-near-api-js@^5.0.0:
+near-api-js@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-5.0.1.tgz#a393547cabeeb7a8a445a4d786ec3aef948e0d84"
   integrity sha512-ZSQYIQdekIvSRfOFuRj6MW11jtK5lsOaiWM2VB0nq7eROuuxwSSXHg+syjCXl3HNNZ3hzg0CNdp+5Za0X1ZtYg==


### PR DESCRIPTION
The MPC Sign Requests are timing out when calling `account.signAndSendTransaction`. This appears to be buried deeply in the non-configurable `provider.txStatus` polling (when waiting for an EXECUTED status).

Add alternate/semi-manual transaction broadcast & result fetching as follows:

 - signTransaction
 - sendTransactionAsync
 - poll txStatus for INCLUDED instead of EXECUTED on a loop until EXECUTED (with 1 second/block sleep).


This is entirely due to some usability issue with near-js/providers: https://github.com/near/near-api-js/issues/1448

