### PR TITLE
Improve TypedDataDomain guard

### DIFF
--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -22,7 +22,9 @@ export function isSignMethod(method: unknown): method is SignMethod {
   );
 }
 
-const isTypedDataDomain = (domain: unknown): domain is TypedDataDomain => {
+export const isTypedDataDomain = (
+  domain: unknown
+): domain is TypedDataDomain => {
   if (typeof domain !== "object" || domain === null) return false;
 
   const candidate = domain as Record<string, unknown>;
@@ -34,7 +36,8 @@ const isTypedDataDomain = (domain: unknown): domain is TypedDataDomain => {
         return (
           typeof value === "undefined" ||
           typeof value === "number" ||
-          isHex(value)
+          isHex(value) ||
+          (typeof value === "string" && typeof parseInt(value) === "number")
         );
       case "name":
       case "version":

--- a/tests/unit/types.guards.test.ts
+++ b/tests/unit/types.guards.test.ts
@@ -4,6 +4,7 @@ import {
   isRlpHex,
   isSignMethod,
   isTransactionSerializable,
+  isTypedDataDomain,
 } from "../../src/";
 
 const validEIP1559Transaction: TransactionSerializable = {
@@ -142,6 +143,31 @@ describe("isTransactionSerializable", () => {
     commonInvalidCases.forEach((testCase) => {
       expect(isTransactionSerializable(testCase)).toBe(false);
     });
+  });
+});
+
+describe("isTypedDataDomain", () => {
+  it("returns true for various valid domains", async () => {
+    const permit2Domain = {
+      name: "Permit2",
+      chainId: "43114",
+      verifyingContract: "0x000000000022d473030f116ddee9f6b43ac78ba3",
+    };
+    expect(isTypedDataDomain(permit2Domain)).toBe(true);
+    expect(
+      isTypedDataDomain({
+        name: "Ether Mail",
+        version: "1",
+        chainId: 1,
+        verifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+      })
+    ).toBe(true);
+    expect(
+      isTypedDataDomain({
+        chainId: "0xaa36a7",
+        verifyingContract: "0x7fa8e8264985c7525fc50f98ac1a9b3765405489",
+      })
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
Uniswap WC requests had chainId as a string in the domain structure. This PR improves the type guard to capture this.