### PR TITLE
Migration: Walletconnect to Reown

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
+    "@reown/walletkit": "^1.2.0",
     "@walletconnect/web3wallet": "^1.13.0",
     "elliptic": "^6.5.6",
     "near-api-js": "^5.0.1",

--- a/src/beta.ts
+++ b/src/beta.ts
@@ -1,3 +1,4 @@
+import { WalletKitTypes } from "@reown/walletkit";
 import { Hex, Signature, serializeSignature } from "viem";
 import {
   addSignature,
@@ -6,7 +7,6 @@ import {
 } from "./utils/transaction";
 import { isSignMethod, NearEncodedSignRequest, signMethods } from "./types";
 import { NearEthAdapter } from "./chains/ethereum";
-import { Web3WalletTypes } from "@walletconnect/web3wallet";
 import { requestRouter } from "./utils/request";
 
 function stripEip155Prefix(eip155Address: string): string {
@@ -25,7 +25,7 @@ export class Beta {
   }
 
   async handleSessionRequest(
-    request: Partial<Web3WalletTypes.SessionRequest>
+    request: Partial<WalletKitTypes.SessionRequest>
   ): Promise<NearEncodedSignRequest> {
     const {
       chainId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,6 +1157,19 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
   integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
 
+"@reown/walletkit@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@reown/walletkit/-/walletkit-1.2.0.tgz#ca0cdc1164b2800fe9f433c7047a318d5a41518a"
+  integrity sha512-f7ztzW4sMeMImLdeW/ZuVxRDxp5zfPhAUEG/DbC2D9irKWC2qUubc4lTk/CvzjGLY9kJTneYI+IzSkSz1lqZ3A==
+  dependencies:
+    "@walletconnect/core" "2.18.0"
+    "@walletconnect/jsonrpc-provider" "1.0.14"
+    "@walletconnect/jsonrpc-utils" "1.0.8"
+    "@walletconnect/logger" "2.1.2"
+    "@walletconnect/sign-client" "2.18.0"
+    "@walletconnect/types" "2.18.0"
+    "@walletconnect/utils" "2.18.0"
+
 "@scure/base@~1.2.2", "@scure/base@~1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.4.tgz#002eb571a35d69bdb4c214d0995dff76a8dcd2a9"
@@ -1580,7 +1593,7 @@
     lodash.isequal "4.5.0"
     uint8arrays "3.1.0"
 
-"@walletconnect/core@^2.10.1":
+"@walletconnect/core@2.18.0", "@walletconnect/core@^2.10.1":
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.18.0.tgz#749b57000823eceb1c667d38531e7eae206df349"
   integrity sha512-i/olu/IwYtBiWYqyfNUMxq4b6QS5dv+ZVVGmLT2buRwdH6MGETN0Bx3/z6rXJzd1sNd+QL07fxhSFxCekL57tA==
@@ -1740,6 +1753,21 @@
     "@walletconnect/time" "1.0.2"
     "@walletconnect/types" "2.17.1"
     "@walletconnect/utils" "2.17.1"
+    events "3.3.0"
+
+"@walletconnect/sign-client@2.18.0":
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.18.0.tgz#33480ee3e711d31c947860125ac26cf31bb9bcb5"
+  integrity sha512-oUjlRIsbHxMSRif2WvMRdvm6tMsQjMj07rl7YVcKVvZ1gF1/9GcbJPjzL/U87fv8qAQkVhIlbEg2vHaVYf6J/g==
+  dependencies:
+    "@walletconnect/core" "2.18.0"
+    "@walletconnect/events" "1.0.1"
+    "@walletconnect/heartbeat" "1.2.2"
+    "@walletconnect/jsonrpc-utils" "1.0.8"
+    "@walletconnect/logger" "2.1.2"
+    "@walletconnect/time" "1.0.2"
+    "@walletconnect/types" "2.18.0"
+    "@walletconnect/utils" "2.18.0"
     events "3.3.0"
 
 "@walletconnect/time@1.0.2", "@walletconnect/time@^1.0.2":


### PR DESCRIPTION
There were some warnings:

```
warning @walletconnect/web3wallet > @walletconnect/core > lodash.isequal@4.5.0: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
warning @walletconnect/web3wallet > @walletconnect/auth-client > @walletconnect/core > lodash.isequal@4.5.0: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
```

Seems related to https://docs.reown.com/advanced/walletconnect-deprecations