### PR TITLE
Replace Ankr RPC for Avalanche

### DIFF
--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -4,7 +4,7 @@ import { CHAIN_INFO } from "./constants";
 
 /** Custom RPC endpoint overrides for specific chain IDs */
 const rpcOverrides: { [key: number]: string } = {
-  43114: "https://rpc.ankr.com/avalanche",
+  43114: "https://avalanche.drpc.org",
   11155111: "https://ethereum-sepolia-rpc.publicnode.com",
 };
 


### PR DESCRIPTION
Ankr seems to require an API key now (for accessing avalanche at least).

See for yourself here: https://rpc.ankr.com/avalanche

Returns:

```sh
{
  "jsonrpc": "2.0", 
  "error": {
    "code": -32000, 
    "message": "Unauthorized: You must authenticate your request with an API key. Create an account on https://www.ankr.com/rpc/ and generate your personal API key for free."
  }, 
  "id": null
}
```

Also for others: https://rpc.ankr.com/eth

We replace with a free node.

## Test Plan

try this out:

```sh
curl -X POST https://avalanche.drpc.org \
  -H "Content-Type: application/json" \
  -d '{
    "jsonrpc":"2.0",
    "method":"eth_call",
    "params":[
      {
        "to":"0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7",
        "data":"0x95d89b41"
      },
      "latest"
    ],
    "id":1
  }'
```